### PR TITLE
Updated to Babel 6 and updated other dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "stage": 0,
-  "loose": "all"
+  "presets": ["es2015", "stage-0"]
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ library-boilerplate
 
 An opinionated setup I plan to use for my libraries.
 
-It has CommonJS and UMD builds via Babel and Webpack, ESLint, and Mocha.  
+It has CommonJS and UMD builds via Babel and Webpack, ESLint, and Mocha.
 It also has React-friendly examples folder with library code mapped to the sources.
 
 If you use this, make sure to grep for “library-boilerplate” and replace every occurrence.
@@ -11,7 +11,7 @@ See `package.json` in the root and the example folder for the list of the availa
 
 Note that this is an *opinionated* boilerplate. You might want to:
 
-* Set `stage` to `2` in `.babelrc` so you don’t depend on language features that might be gone tomorrow;
-* Remove `loose: ["all"]` from `.babelrc` so the behavior is spec-compliant.
+* Install `babel-preset-stage-2` instead of `babel-preset-stage-0` so you don’t depend on language features that might be gone tomorrow;
+* Add `loose` mode in `.babelrc` by installing `babel-preset-es2015-loose`.
 
 You have been warned.

--- a/package.json
+++ b/package.json
@@ -27,21 +27,24 @@
   },
   "homepage": "https://github.com/library-boilerplate-author/library-boilerplate",
   "devDependencies": {
-    "babel": "^5.5.8",
-    "babel-core": "^5.6.18",
-    "babel-eslint": "^3.1.15",
-    "babel-loader": "^5.1.4",
-    "eslint": "^0.23",
-    "eslint-config-airbnb": "0.0.6",
-    "eslint-plugin-react": "^2.3.0",
-    "expect": "^1.6.0",
+    "babel": "^6.3.13",
+    "babel-cli": "^6.3.17",
+    "babel-core": "^6.3.17",
+    "babel-eslint": "^4.1.6",
+    "babel-loader": "^6.2.0",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
+    "eslint": "^1.10",
+    "eslint-config-airbnb": "2.1.1",
+    "eslint-plugin-react": "^3.11.3",
+    "expect": "^1.13.4",
     "isparta": "^3.0.3",
-    "mocha": "^2.2.5",
-    "rimraf": "^2.3.4",
-    "webpack": "^1.9.6",
-    "webpack-dev-server": "^1.8.2"
+    "mocha": "^2.3.4",
+    "rimraf": "^2.4.4",
+    "webpack": "^1.12.9",
+    "webpack-dev-server": "^1.14.0"
   },
   "dependencies": {
-    "invariant": "^2.0.0"
+    "invariant": "^2.2.0"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
---compilers js:babel/register
+--compilers js:babel-core/register
 --recursive


### PR DESCRIPTION
Babel 6, see: https://github.com/gaearon/library-boilerplate/pull/9
